### PR TITLE
Change discord invite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ If you are developing using Cardinal staking contracts and libraries, feel free 
 
 For issues please, file a GitHub issue.
 
-> https://discord.gg/bz2SxDQ8
+> https://discord.gg/byq6uNTugq
 
 ## License
 


### PR DESCRIPTION
The old invite was invalid. Took the new one from cardinal.so