### PR TITLE
Restake functionality

### DIFF
--- a/programs/cardinal-reward-distributor/src/state.rs
+++ b/programs/cardinal-reward-distributor/src/state.rs
@@ -18,7 +18,7 @@ pub struct RewardEntry {
     pub multiplier: u64,
 }
 
-#[derive(Clone, Debug, PartialEq, AnchorSerialize, AnchorDeserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, AnchorSerialize, AnchorDeserialize)]
 #[repr(u8)]
 pub enum RewardDistributorKind {
     /// Rewards are distributed by minting new tokens

--- a/programs/cardinal-stake-pool/src/instructions/stake.rs
+++ b/programs/cardinal-stake-pool/src/instructions/stake.rs
@@ -40,8 +40,8 @@ pub struct StakeCtx<'info> {
 pub fn handler(ctx: Context<StakeCtx>, amount: u64) -> Result<()> {
     let stake_pool = &mut ctx.accounts.stake_pool;
     let stake_entry = &mut ctx.accounts.stake_entry;
-    if stake_entry.amount > 0 {
-        return Err(error!(ErrorCode::StakeEntryAlreadyStaked));
+    if stake_entry.cooldown_start_seconds.is_some() {
+        return Err(error!(ErrorCode::CooldownSecondRemaining));
     }
 
     if stake_entry.amount != 0 {

--- a/programs/cardinal-stake-pool/src/instructions/stake.rs
+++ b/programs/cardinal-stake-pool/src/instructions/stake.rs
@@ -14,8 +14,7 @@ pub struct StakeCtx<'info> {
 
     // stake_entry token accounts
     #[account(mut, constraint =
-        stake_entry_original_mint_token_account.amount == 0
-        && stake_entry_original_mint_token_account.mint == stake_entry.original_mint
+        stake_entry_original_mint_token_account.mint == stake_entry.original_mint
         && stake_entry_original_mint_token_account.owner == stake_entry.key()
         @ ErrorCode::InvalidStakeEntryOriginalMintTokenAccount
     )]

--- a/programs/cardinal-stake-pool/src/instructions/stake.rs
+++ b/programs/cardinal-stake-pool/src/instructions/stake.rs
@@ -44,6 +44,18 @@ pub fn handler(ctx: Context<StakeCtx>, amount: u64) -> Result<()> {
         return Err(error!(ErrorCode::StakeEntryAlreadyStaked));
     }
 
+    if stake_entry.amount != 0 {
+        stake_entry.total_stake_seconds = stake_entry.total_stake_seconds.saturating_add(
+            (stake_entry
+                .cooldown_start_seconds
+                .unwrap_or(Clock::get().unwrap().unix_timestamp)
+                .checked_sub(stake_entry.last_staked_at)
+                .unwrap() as u64)
+                .checked_mul(stake_entry.amount)
+                .unwrap() as u128,
+        );
+    }
+
     // transfer original
     let cpi_accounts = token::Transfer {
         from: ctx.accounts.user_original_mint_token_account.to_account_info(),
@@ -54,15 +66,15 @@ pub fn handler(ctx: Context<StakeCtx>, amount: u64) -> Result<()> {
     let cpi_context = CpiContext::new(cpi_program, cpi_accounts);
     token::transfer(cpi_context, amount)?;
 
+    if stake_pool.reset_on_stake && stake_entry.amount == 0 {
+        stake_entry.total_stake_seconds = 0;
+    }
+
     // update stake entry
     stake_entry.last_staked_at = Clock::get().unwrap().unix_timestamp;
     stake_entry.last_staker = ctx.accounts.user.key();
-    stake_entry.amount = amount;
+    stake_entry.amount = stake_entry.amount.checked_add(amount).unwrap();
     stake_pool.total_staked = stake_pool.total_staked.checked_add(1).expect("Add error");
-
-    if ctx.accounts.stake_pool.reset_on_stake {
-        stake_entry.total_stake_seconds = 0;
-    }
 
     Ok(())
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -367,6 +367,12 @@ export const stake = async (
         "Stake entry has no stake mint. Initialize stake mint first."
       );
     }
+    if (
+      stakeEntryData?.parsed.stakeMintClaimed ||
+      stakeEntryData?.parsed.originalMintClaimed
+    ) {
+      throw new Error("Receipt has already been claimed.");
+    }
 
     await withClaimReceiptMint(transaction, connection, wallet, {
       stakePoolId: params.stakePoolId,

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,8 @@
 import { tryGetAccount } from "@cardinal/common";
 import { BN } from "@project-serum/anchor";
 import type { Wallet } from "@saberhq/solana-contrib";
-import type { Connection } from "@solana/web3.js";
-import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import type { Connection, PublicKey } from "@solana/web3.js";
+import { Keypair, Transaction } from "@solana/web3.js";
 
 import type { RewardDistributorKind } from "./programs/rewardDistributor";
 import { findRewardDistributorId } from "./programs/rewardDistributor/pda";
@@ -348,14 +348,6 @@ export const stake = async (
       stakePoolId: params.stakePoolId,
       originalMintId: params.originalMintId,
     });
-  } else if (
-    stakeEntryData.parsed.lastStaker.toString() !==
-      PublicKey.default.toString() &&
-    supply.gt(new BN(1))
-  ) {
-    throw new Error(
-      "User has fungible tokens already staked in the pool. Staked tokens need to be unstaked and then restaked together with the new tokens."
-    );
   }
 
   await withStake(transaction, connection, wallet, {

--- a/tests/fungible-staking-add-amount.spec.ts
+++ b/tests/fungible-staking-add-amount.spec.ts
@@ -243,32 +243,30 @@ describe("Create stake pool", () => {
       true
     );
 
+    expect(stakeEntryData.parsed.amount.toNumber()).to.eq(stakingAmount / 2);
+    expect(stakeEntryData.parsed.lastStakedAt.toNumber()).to.be.greaterThan(0);
+    expect(stakeEntryData.parsed.lastStaker.toString()).to.eq(
+      provider.wallet.publicKey.toString()
+    );
+
+    const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
+      userOriginalMintTokenAccountId
+    );
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(
+      stakingAmount / 2
+    );
+
+    const checkStakeEntryOriginalMintTokenAccount =
+      await originalMint.getAccountInfo(stakeEntryOriginalMintTokenAccountId);
+    expect(checkStakeEntryOriginalMintTokenAccount.amount.toNumber()).to.eq(
+      stakingAmount / 2
+    );
+
     if (stakeMintKeypair) {
       const userReceiptTokenAccountId = await findAta(
         stakeMintKeypair.publicKey,
         provider.wallet.publicKey,
         true
-      );
-
-      expect(stakeEntryData.parsed.amount.toNumber()).to.eq(stakingAmount / 2);
-      expect(stakeEntryData.parsed.lastStakedAt.toNumber()).to.be.greaterThan(
-        0
-      );
-      expect(stakeEntryData.parsed.lastStaker.toString()).to.eq(
-        provider.wallet.publicKey.toString()
-      );
-
-      const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
-        userOriginalMintTokenAccountId
-      );
-      expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(
-        stakingAmount / 2
-      );
-
-      const checkStakeEntryOriginalMintTokenAccount =
-        await originalMint.getAccountInfo(stakeEntryOriginalMintTokenAccountId);
-      expect(checkStakeEntryOriginalMintTokenAccount.amount.toNumber()).to.eq(
-        stakingAmount / 2
       );
 
       const checkReceiptMint = new splToken.Token(
@@ -323,15 +321,13 @@ describe("Create stake pool", () => {
     const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
       userOriginalMintTokenAccountId
     );
-    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(
-      stakingAmount / 2
-    );
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(0);
 
     const checkStakeEntryOriginalMintTokenAccount =
       await originalMint.getAccountInfo(stakeEntryOriginalMintTokenAccountId);
 
     expect(checkStakeEntryOriginalMintTokenAccount.amount.toNumber()).to.eq(
-      stakingAmount / 2
+      stakingAmount
     );
   });
 
@@ -373,7 +369,9 @@ describe("Create stake pool", () => {
     const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
       userOriginalMintTokenAccountId
     );
-    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(10);
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(
+      stakingAmount
+    );
     expect(checkUserOriginalTokenAccount.isFrozen).to.eq(false);
   });
 });

--- a/tests/fungible-staking-add-amount.spec.ts
+++ b/tests/fungible-staking-add-amount.spec.ts
@@ -1,0 +1,379 @@
+import { findAta } from "@cardinal/common";
+import { BN } from "@project-serum/anchor";
+import { expectTXTable } from "@saberhq/chai-solana";
+import { SolanaProvider, TransactionEnvelope } from "@saberhq/solana-contrib";
+import * as splToken from "@solana/spl-token";
+import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import { expect } from "chai";
+
+import {
+  createStakeEntryAndStakeMint,
+  createStakePool,
+  initializeRewardEntry,
+  rewardDistributor,
+  stake,
+  unstake,
+} from "../src";
+import { RewardDistributorKind } from "../src/programs/rewardDistributor";
+import { getRewardDistributor } from "../src/programs/rewardDistributor/accounts";
+import { findRewardDistributorId } from "../src/programs/rewardDistributor/pda";
+import { ReceiptType } from "../src/programs/stakePool";
+import { getStakeEntry } from "../src/programs/stakePool/accounts";
+import { findStakeEntryIdFromMint } from "../src/programs/stakePool/utils";
+import { createMint } from "./utils";
+import { getProvider } from "./workspace";
+
+describe("Create stake pool", () => {
+  let stakePoolId: PublicKey;
+  let originalMintTokenAccountId: PublicKey;
+  let originalMint: splToken.Token;
+  let rewardMint: splToken.Token;
+
+  const maxSupply = 100;
+  const stakingAmount = 10;
+  const originalMintAuthority = Keypair.generate();
+  const rewardMintAuthority = Keypair.generate();
+  let stakeMintKeypair: Keypair | undefined;
+
+  before(async () => {
+    const provider = getProvider();
+    // original mint
+    [originalMintTokenAccountId, originalMint] = await createMint(
+      provider.connection,
+      originalMintAuthority,
+      provider.wallet.publicKey,
+      stakingAmount,
+      originalMintAuthority.publicKey
+    );
+
+    // reward mint
+    [, rewardMint] = await createMint(
+      provider.connection,
+      rewardMintAuthority,
+      provider.wallet.publicKey,
+      maxSupply,
+      rewardMintAuthority.publicKey
+    );
+  });
+
+  it("Create Pool", async () => {
+    const provider = getProvider();
+
+    let transaction: Transaction;
+    [transaction, stakePoolId] = await createStakePool(
+      provider.connection,
+      provider.wallet,
+      {}
+    );
+
+    await expectTXTable(
+      new TransactionEnvelope(SolanaProvider.init(provider), [
+        ...transaction.instructions,
+      ]),
+      "Create pool"
+    ).to.be.fulfilled;
+  });
+
+  it("Create Reward Distributor", async () => {
+    const provider = getProvider();
+    const transaction = new Transaction();
+    await rewardDistributor.transaction.withInitRewardDistributor(
+      transaction,
+      provider.connection,
+      provider.wallet,
+      {
+        stakePoolId: stakePoolId,
+        rewardMintId: rewardMint.publicKey,
+        kind: RewardDistributorKind.Treasury,
+        maxSupply: new BN(maxSupply),
+      }
+    );
+
+    const txEnvelope = new TransactionEnvelope(
+      SolanaProvider.init({
+        connection: provider.connection,
+        wallet: provider.wallet,
+        opts: provider.opts,
+      }),
+      [...transaction.instructions]
+    );
+
+    await expectTXTable(txEnvelope, "Create reward distributor", {
+      verbosity: "error",
+      formatLogs: true,
+    }).to.be.fulfilled;
+
+    const [rewardDistributorId] = await findRewardDistributorId(stakePoolId);
+    const rewardDistributorData = await getRewardDistributor(
+      provider.connection,
+      rewardDistributorId
+    );
+
+    expect(rewardDistributorData.parsed.rewardMint.toString()).to.eq(
+      rewardMint.publicKey.toString()
+    );
+  });
+
+  it("Init Reward Entry", async () => {
+    const provider = getProvider();
+    const [rewardDistributorId] = await findRewardDistributorId(stakePoolId);
+    const transaction = await initializeRewardEntry(
+      provider.connection,
+      provider.wallet,
+      {
+        originalMintId: originalMint.publicKey,
+        stakePoolId: stakePoolId,
+      }
+    );
+
+    const txEnvelope = new TransactionEnvelope(SolanaProvider.init(provider), [
+      ...transaction.instructions,
+    ]);
+
+    await expectTXTable(txEnvelope, "Init reward entry", {
+      verbosity: "error",
+      formatLogs: true,
+    }).to.be.fulfilled;
+
+    const rewardDistributorData = await getRewardDistributor(
+      provider.connection,
+      rewardDistributorId
+    );
+
+    expect(rewardDistributorData.parsed.rewardMint.toString()).to.eq(
+      rewardMint.publicKey.toString()
+    );
+  });
+
+  it("Init fungible stake entry and stake mint", async () => {
+    const provider = getProvider();
+    let transaction: Transaction;
+
+    [transaction, , stakeMintKeypair] = await createStakeEntryAndStakeMint(
+      provider.connection,
+      provider.wallet,
+      {
+        stakePoolId: stakePoolId,
+        originalMintId: originalMint.publicKey,
+      }
+    );
+
+    await expectTXTable(
+      new TransactionEnvelope(
+        SolanaProvider.init(provider),
+        [...transaction.instructions],
+        stakeMintKeypair ? [stakeMintKeypair] : []
+      ),
+      "Init fungible stake entry"
+    ).to.be.fulfilled;
+
+    const stakeEntryData = await getStakeEntry(
+      provider.connection,
+      (
+        await findStakeEntryIdFromMint(
+          provider.connection,
+          provider.wallet.publicKey,
+          stakePoolId,
+          originalMint.publicKey
+        )
+      )[0]
+    );
+
+    expect(stakeEntryData.parsed.originalMint.toString()).to.eq(
+      originalMint.publicKey.toString()
+    );
+    expect(stakeEntryData.parsed.pool.toString()).to.eq(stakePoolId.toString());
+    if (stakeMintKeypair) {
+      expect(stakeEntryData.parsed.stakeMint?.toString()).to.eq(
+        stakeMintKeypair.publicKey.toString()
+      );
+
+      const checkMint = new splToken.Token(
+        provider.connection,
+        stakeMintKeypair.publicKey,
+        splToken.TOKEN_PROGRAM_ID,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        null
+      );
+
+      expect((await checkMint.getMintInfo()).isInitialized).to.be.true;
+    }
+  });
+
+  it("Stake half", async () => {
+    const provider = getProvider();
+
+    await expectTXTable(
+      new TransactionEnvelope(SolanaProvider.init(provider), [
+        ...(
+          await stake(provider.connection, provider.wallet, {
+            stakePoolId: stakePoolId,
+            originalMintId: originalMint.publicKey,
+            userOriginalMintTokenAccountId: originalMintTokenAccountId,
+            receiptType: ReceiptType.Receipt,
+            amount: new BN(stakingAmount / 2),
+          })
+        ).instructions,
+      ]),
+      "Stake half"
+    ).to.be.fulfilled;
+
+    const stakeEntryData = await getStakeEntry(
+      provider.connection,
+      (
+        await findStakeEntryIdFromMint(
+          provider.connection,
+          provider.wallet.publicKey,
+          stakePoolId,
+          originalMint.publicKey
+        )
+      )[0]
+    );
+
+    const userOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+
+    const stakeEntryOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      stakeEntryData.pubkey,
+      true
+    );
+
+    if (stakeMintKeypair) {
+      const userReceiptTokenAccountId = await findAta(
+        stakeMintKeypair.publicKey,
+        provider.wallet.publicKey,
+        true
+      );
+
+      expect(stakeEntryData.parsed.amount.toNumber()).to.eq(stakingAmount / 2);
+      expect(stakeEntryData.parsed.lastStakedAt.toNumber()).to.be.greaterThan(
+        0
+      );
+      expect(stakeEntryData.parsed.lastStaker.toString()).to.eq(
+        provider.wallet.publicKey.toString()
+      );
+
+      const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
+        userOriginalMintTokenAccountId
+      );
+      expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(
+        stakingAmount / 2
+      );
+
+      const checkStakeEntryOriginalMintTokenAccount =
+        await originalMint.getAccountInfo(stakeEntryOriginalMintTokenAccountId);
+      expect(checkStakeEntryOriginalMintTokenAccount.amount.toNumber()).to.eq(
+        stakingAmount / 2
+      );
+
+      const checkReceiptMint = new splToken.Token(
+        provider.connection,
+        stakeMintKeypair.publicKey,
+        splToken.TOKEN_PROGRAM_ID,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        null
+      );
+      const userReceiptTokenAccount = await checkReceiptMint.getAccountInfo(
+        userReceiptTokenAccountId
+      );
+      expect(userReceiptTokenAccount.amount.toNumber()).to.eq(1);
+    }
+  });
+
+  it("Stake another half", async () => {
+    const provider = getProvider();
+
+    await stake(provider.connection, provider.wallet, {
+      stakePoolId: stakePoolId,
+      originalMintId: originalMint.publicKey,
+      userOriginalMintTokenAccountId: originalMintTokenAccountId,
+      receiptType: ReceiptType.Receipt,
+      amount: new BN(stakingAmount / 2),
+    });
+
+    const stakeEntryData = await getStakeEntry(
+      provider.connection,
+      (
+        await findStakeEntryIdFromMint(
+          provider.connection,
+          provider.wallet.publicKey,
+          stakePoolId,
+          originalMint.publicKey
+        )
+      )[0]
+    );
+    const userOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+
+    const stakeEntryOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      stakeEntryData.pubkey,
+      true
+    );
+
+    const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
+      userOriginalMintTokenAccountId
+    );
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(
+      stakingAmount / 2
+    );
+
+    const checkStakeEntryOriginalMintTokenAccount =
+      await originalMint.getAccountInfo(stakeEntryOriginalMintTokenAccountId);
+
+    expect(checkStakeEntryOriginalMintTokenAccount.amount.toNumber()).to.eq(
+      stakingAmount / 2
+    );
+  });
+
+  it("Unstake", async () => {
+    const provider = getProvider();
+    await expectTXTable(
+      new TransactionEnvelope(SolanaProvider.init(provider), [
+        ...(
+          await unstake(provider.connection, provider.wallet, {
+            stakePoolId: stakePoolId,
+            originalMintId: originalMint.publicKey,
+          })
+        ).instructions,
+      ]),
+      "Unstake"
+    ).to.be.fulfilled;
+
+    const stakeEntryData = await getStakeEntry(
+      provider.connection,
+      (
+        await findStakeEntryIdFromMint(
+          provider.connection,
+          provider.wallet.publicKey,
+          stakePoolId,
+          originalMint.publicKey
+        )
+      )[0]
+    );
+    expect(stakeEntryData.parsed.lastStaker.toString()).to.eq(
+      PublicKey.default.toString()
+    );
+    expect(stakeEntryData.parsed.lastStakedAt.toNumber()).to.gt(0);
+
+    const userOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+    const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
+      userOriginalMintTokenAccountId
+    );
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(10);
+    expect(checkUserOriginalTokenAccount.isFrozen).to.eq(false);
+  });
+});

--- a/tests/fungible-staking-add-amount.spec.ts
+++ b/tests/fungible-staking-add-amount.spec.ts
@@ -308,7 +308,6 @@ describe("Create stake pool", () => {
             stakePoolId: stakePoolId,
             originalMintId: originalMint.publicKey,
             userOriginalMintTokenAccountId: originalMintTokenAccountId,
-            receiptType: ReceiptType.Receipt,
             amount: new BN(stakingAmount / 2),
           })
         ).instructions,

--- a/tests/fungible-staking-add-during-cooldown.spec.ts
+++ b/tests/fungible-staking-add-during-cooldown.spec.ts
@@ -151,7 +151,9 @@ describe("Create stake pool", () => {
       stakeEntryData.pubkey,
       true
     );
-    expect(stakeEntryData.parsed.cooldownStartSeconds).to.be.greaterThan(0);
+    expect(
+      stakeEntryData.parsed.cooldownStartSeconds?.toNumber()
+    ).to.be.greaterThan(0);
     expect(stakeEntryData.parsed.amount.toNumber()).to.eq(stakingAmount / 2);
     expect(stakeEntryData.parsed.lastStakedAt.toNumber()).to.be.greaterThan(0);
     expect(stakeEntryData.parsed.lastStaker.toString()).to.eq(

--- a/tests/fungible-staking-add-during-cooldown.spec.ts
+++ b/tests/fungible-staking-add-during-cooldown.spec.ts
@@ -8,7 +8,6 @@ import { Keypair } from "@solana/web3.js";
 import { expect } from "chai";
 
 import { createStakePool, stake, unstake } from "../src";
-import { ReceiptType } from "../src/programs/stakePool";
 import { getStakeEntry } from "../src/programs/stakePool/accounts";
 import { findStakeEntryIdFromMint } from "../src/programs/stakePool/utils";
 import { createMint } from "./utils";
@@ -64,7 +63,6 @@ describe("Create stake pool", () => {
             stakePoolId: stakePoolId,
             originalMintId: originalMint.publicKey,
             userOriginalMintTokenAccountId: originalMintTokenAccountId,
-            receiptType: ReceiptType.Receipt,
             amount: new BN(stakingAmount / 2),
           })
         ).instructions,
@@ -184,7 +182,6 @@ describe("Create stake pool", () => {
               stakePoolId: stakePoolId,
               originalMintId: originalMint.publicKey,
               userOriginalMintTokenAccountId: originalMintTokenAccountId,
-              receiptType: ReceiptType.Receipt,
               amount: new BN(stakingAmount / 2),
             })
           ).instructions,

--- a/tests/fungible-staking-add-during-cooldown.spec.ts
+++ b/tests/fungible-staking-add-during-cooldown.spec.ts
@@ -1,0 +1,196 @@
+import { findAta } from "@cardinal/common";
+import { BN } from "@project-serum/anchor";
+import { expectTXTable } from "@saberhq/chai-solana";
+import { SolanaProvider, TransactionEnvelope } from "@saberhq/solana-contrib";
+import type * as splToken from "@solana/spl-token";
+import type { PublicKey, Transaction } from "@solana/web3.js";
+import { Keypair } from "@solana/web3.js";
+import { expect } from "chai";
+
+import { createStakePool, stake, unstake } from "../src";
+import { ReceiptType } from "../src/programs/stakePool";
+import { getStakeEntry } from "../src/programs/stakePool/accounts";
+import { findStakeEntryIdFromMint } from "../src/programs/stakePool/utils";
+import { createMint } from "./utils";
+import { getProvider } from "./workspace";
+
+describe("Create stake pool", () => {
+  let stakePoolId: PublicKey;
+  let originalMintTokenAccountId: PublicKey;
+  let originalMint: splToken.Token;
+
+  const stakingAmount = 10;
+  const originalMintAuthority = Keypair.generate();
+
+  before(async () => {
+    const provider = getProvider();
+    // original mint
+    [originalMintTokenAccountId, originalMint] = await createMint(
+      provider.connection,
+      originalMintAuthority,
+      provider.wallet.publicKey,
+      stakingAmount,
+      originalMintAuthority.publicKey
+    );
+  });
+
+  it("Create Pool", async () => {
+    const provider = getProvider();
+
+    let transaction: Transaction;
+    [transaction, stakePoolId] = await createStakePool(
+      provider.connection,
+      provider.wallet,
+      {
+        cooldownSeconds: 10,
+      }
+    );
+
+    await expectTXTable(
+      new TransactionEnvelope(SolanaProvider.init(provider), [
+        ...transaction.instructions,
+      ]),
+      "Create pool"
+    ).to.be.fulfilled;
+  });
+
+  it("Stake half", async () => {
+    const provider = getProvider();
+
+    await expectTXTable(
+      new TransactionEnvelope(SolanaProvider.init(provider), [
+        ...(
+          await stake(provider.connection, provider.wallet, {
+            stakePoolId: stakePoolId,
+            originalMintId: originalMint.publicKey,
+            userOriginalMintTokenAccountId: originalMintTokenAccountId,
+            receiptType: ReceiptType.Receipt,
+            amount: new BN(stakingAmount / 2),
+          })
+        ).instructions,
+      ]),
+      "Stake half"
+    ).to.be.fulfilled;
+
+    const stakeEntryData = await getStakeEntry(
+      provider.connection,
+      (
+        await findStakeEntryIdFromMint(
+          provider.connection,
+          provider.wallet.publicKey,
+          stakePoolId,
+          originalMint.publicKey
+        )
+      )[0]
+    );
+
+    const userOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+
+    const stakeEntryOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      stakeEntryData.pubkey,
+      true
+    );
+
+    expect(stakeEntryData.parsed.amount.toNumber()).to.eq(stakingAmount / 2);
+    expect(stakeEntryData.parsed.lastStakedAt.toNumber()).to.be.greaterThan(0);
+    expect(stakeEntryData.parsed.lastStaker.toString()).to.eq(
+      provider.wallet.publicKey.toString()
+    );
+
+    const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
+      userOriginalMintTokenAccountId
+    );
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(
+      stakingAmount / 2
+    );
+
+    const checkStakeEntryOriginalMintTokenAccount =
+      await originalMint.getAccountInfo(stakeEntryOriginalMintTokenAccountId);
+    expect(checkStakeEntryOriginalMintTokenAccount.amount.toNumber()).to.eq(
+      stakingAmount / 2
+    );
+  });
+
+  it("Unstake", async () => {
+    const provider = getProvider();
+    await expectTXTable(
+      new TransactionEnvelope(SolanaProvider.init(provider), [
+        ...(
+          await unstake(provider.connection, provider.wallet, {
+            stakePoolId: stakePoolId,
+            originalMintId: originalMint.publicKey,
+          })
+        ).instructions,
+      ]),
+      "Unstake into cooldown"
+    ).to.be.fulfilled;
+
+    const stakeEntryData = await getStakeEntry(
+      provider.connection,
+      (
+        await findStakeEntryIdFromMint(
+          provider.connection,
+          provider.wallet.publicKey,
+          stakePoolId,
+          originalMint.publicKey
+        )
+      )[0]
+    );
+
+    const userOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+
+    const stakeEntryOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      stakeEntryData.pubkey,
+      true
+    );
+    expect(stakeEntryData.parsed.cooldownStartSeconds).to.be.greaterThan(0);
+    expect(stakeEntryData.parsed.amount.toNumber()).to.eq(stakingAmount / 2);
+    expect(stakeEntryData.parsed.lastStakedAt.toNumber()).to.be.greaterThan(0);
+    expect(stakeEntryData.parsed.lastStaker.toString()).to.eq(
+      provider.wallet.publicKey.toString()
+    );
+
+    const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
+      userOriginalMintTokenAccountId
+    );
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(
+      stakingAmount / 2
+    );
+
+    const checkStakeEntryOriginalMintTokenAccount =
+      await originalMint.getAccountInfo(stakeEntryOriginalMintTokenAccountId);
+    expect(checkStakeEntryOriginalMintTokenAccount.amount.toNumber()).to.eq(
+      stakingAmount / 2
+    );
+  });
+
+  it("Stake another half during cooldown", () => {
+    const provider = getProvider();
+    expect(async () => {
+      await expectTXTable(
+        new TransactionEnvelope(SolanaProvider.init(provider), [
+          ...(
+            await stake(provider.connection, provider.wallet, {
+              stakePoolId: stakePoolId,
+              originalMintId: originalMint.publicKey,
+              userOriginalMintTokenAccountId: originalMintTokenAccountId,
+              receiptType: ReceiptType.Receipt,
+              amount: new BN(stakingAmount / 2),
+            })
+          ).instructions,
+        ]),
+        "Stake during cooldown"
+      ).to.be.rejectedWith(Error);
+    });
+  });
+});


### PR DESCRIPTION
Support for fungible token staking to change the amount with unstaking

If there is no cooldown `withUnstake` and `withStake` can be used in tadem in a single instruction

If there is cooldown the above approach doesnt work, so it's simpler to just support adding to the existing amount by calling stake again