### PR TITLE
Permissionless update

### DIFF
--- a/programs/cardinal-reward-distributor/src/instructions/claim_rewards.rs
+++ b/programs/cardinal-reward-distributor/src/instructions/claim_rewards.rs
@@ -5,7 +5,7 @@ use {
         solana_program::{program::invoke, system_instruction::transfer},
     },
     anchor_spl::token::{self, Mint, Token, TokenAccount},
-    cardinal_stake_pool::state::{StakeEntry, StakePool},
+    cardinal_stake_pool::state::{StakeEntry, StakeEntryKind, StakePool},
     std::cmp::min,
 };
 
@@ -24,7 +24,7 @@ pub struct ClaimRewardsCtx<'info> {
     #[account(mut, constraint = reward_mint.key() == reward_distributor.reward_mint @ ErrorCode::InvalidRewardMint)]
     reward_mint: Box<Account<'info, Mint>>,
 
-    #[account(mut, constraint = user_reward_mint_token_account.mint == reward_distributor.reward_mint && user_reward_mint_token_account.owner == user.key() @ ErrorCode::InvalidUserRewardMintTokenAccount)]
+    #[account(mut, constraint = user_reward_mint_token_account.mint == reward_distributor.reward_mint @ ErrorCode::InvalidUserRewardMintTokenAccount)]
     user_reward_mint_token_account: Box<Account<'info, TokenAccount>>,
 
     /// CHECK: This is not dangerous because we don't read or write from this account
@@ -47,6 +47,15 @@ pub fn handler<'key, 'accounts, 'remaining, 'info>(ctx: Context<'key, 'accounts,
 
     let reward_amount = reward_distributor.reward_amount;
     let reward_duration_seconds = reward_distributor.reward_duration_seconds;
+
+    if stake_entry.kind == StakeEntryKind::Permissionless as u8
+        // if someone else updated this users stake_entry then it must be checked that they are still the staker - this should be called BEFORE unstake
+        && ctx.accounts.user_reward_mint_token_account.owner != stake_entry.last_staker
+        // can only be signed by the last_staker or the reward distributor authority
+        && (ctx.accounts.user.key() != stake_entry.last_staker || ctx.accounts.user.key() != reward_distributor.authority)
+    {
+        return Err(error!(ErrorCode::InvalidUserRewardMintTokenAccount));
+    }
 
     let reward_seconds_received = reward_entry.reward_seconds_received;
     if reward_seconds_received <= stake_entry.total_stake_seconds && (reward_distributor.max_supply.is_none() || reward_distributor.rewards_issued < reward_distributor.max_supply.unwrap() as u128) {

--- a/programs/cardinal-stake-pool/src/instructions/update_total_stake_seconds.rs
+++ b/programs/cardinal-stake-pool/src/instructions/update_total_stake_seconds.rs
@@ -1,14 +1,11 @@
-use {
-    crate::{errors::ErrorCode, state::*},
-    anchor_lang::prelude::*,
-};
+use {crate::state::*, anchor_lang::prelude::*};
 
 #[derive(Accounts)]
 pub struct UpdateTotalStakeSecondsCtx<'info> {
     #[account(mut)]
     stake_entry: Account<'info, StakeEntry>,
 
-    #[account(mut, constraint = last_staker.key() == stake_entry.last_staker @ErrorCode::InvalidLastStaker)]
+    #[account(mut)]
     last_staker: Signer<'info>,
 }
 
@@ -24,6 +21,10 @@ pub fn handler(ctx: Context<UpdateTotalStakeSecondsCtx>) -> Result<()> {
             .unwrap(),
         );
         stake_entry.last_staked_at = Clock::get().unwrap().unix_timestamp;
+    }
+
+    if ctx.accounts.last_staker.key() != stake_entry.last_staker {
+        stake_entry.kind = StakeEntryKind::Permissionless as u8
     }
     Ok(())
 }

--- a/programs/cardinal-stake-pool/src/state.rs
+++ b/programs/cardinal-stake-pool/src/state.rs
@@ -13,6 +13,13 @@ pub const IDENTIFIER_SIZE: usize = 8 + std::mem::size_of::<Identifier>() + 8;
 pub const STAKE_AUTHORIZATION_PREFIX: &str = "stake-authorization";
 pub const STAKE_AUTHORIZATION_SIZE: usize = 8 + std::mem::size_of::<StakeAuthorizationRecord>() + 8;
 
+#[derive(Clone, Debug, PartialEq, Eq, AnchorSerialize, AnchorDeserialize)]
+#[repr(u8)]
+pub enum StakeEntryKind {
+    Permissioned = 0,   // original
+    Permissionless = 1, // permissionless update_total_stake_seconds was called indicating claim_reward must check signer
+}
+
 #[account]
 pub struct StakeEntry {
     pub bump: u8,

--- a/src/api.ts
+++ b/src/api.ts
@@ -288,6 +288,7 @@ export const claimRewards = async (
   params: {
     stakePoolId: PublicKey;
     stakeEntryId: PublicKey;
+    lastStaker?: PublicKey;
     payer?: PublicKey;
     skipRewardMintTokenAccount?: boolean;
   }
@@ -302,6 +303,7 @@ export const claimRewards = async (
   await withClaimRewards(transaction, connection, wallet, {
     stakePoolId: params.stakePoolId,
     stakeEntryId: params.stakeEntryId,
+    lastStaker: params.lastStaker ?? wallet.publicKey,
     payer: params.payer,
     skipRewardMintTokenAccount: params.skipRewardMintTokenAccount,
   });

--- a/src/idl/cardinal_stake_pool.ts
+++ b/src/idl/cardinal_stake_pool.ts
@@ -846,6 +846,20 @@ export type CardinalStakePool = {
           }
         ];
       };
+    },
+    {
+      name: "StakeEntryKind";
+      type: {
+        kind: "enum";
+        variants: [
+          {
+            name: "Permissioned";
+          },
+          {
+            name: "Permissionless";
+          }
+        ];
+      };
     }
   ];
   errors: [
@@ -1832,6 +1846,20 @@ export const IDL: CardinalStakePool = {
             type: {
               option: "i64",
             },
+          },
+        ],
+      },
+    },
+    {
+      name: "StakeEntryKind",
+      type: {
+        kind: "enum",
+        variants: [
+          {
+            name: "Permissioned",
+          },
+          {
+            name: "Permissionless",
           },
         ],
       },

--- a/src/programs/rewardDistributor/instruction.ts
+++ b/src/programs/rewardDistributor/instruction.ts
@@ -73,6 +73,7 @@ export const initRewardEntry = (
     stakeEntryId: PublicKey;
     rewardDistributor: PublicKey;
     rewardEntryId: PublicKey;
+    payer?: PublicKey;
   }
 ): TransactionInstruction => {
   const provider = new AnchorProvider(connection, wallet, {});
@@ -86,7 +87,7 @@ export const initRewardEntry = (
       rewardEntry: params.rewardEntryId,
       stakeEntry: params.stakeEntryId,
       rewardDistributor: params.rewardDistributor,
-      payer: wallet.publicKey,
+      payer: params.payer ?? wallet.publicKey,
       systemProgram: SystemProgram.programId,
     },
   });
@@ -128,7 +129,7 @@ export const claimRewards = async (
       rewardMint: params.rewardMintId,
       userRewardMintTokenAccount: params.rewardMintTokenAccountId,
       rewardManager: REWARD_MANAGER,
-      user: wallet.publicKey,
+      user: params.payer ?? wallet.publicKey,
       tokenProgram: TOKEN_PROGRAM_ID,
       systemProgram: SystemProgram.programId,
     },

--- a/src/programs/rewardDistributor/transaction.ts
+++ b/src/programs/rewardDistributor/transaction.ts
@@ -100,6 +100,7 @@ export const withClaimRewards = async (
   params: {
     stakePoolId: PublicKey;
     stakeEntryId: PublicKey;
+    lastStaker: PublicKey;
     payer?: PublicKey;
     skipRewardMintTokenAccount?: boolean;
   }
@@ -115,15 +116,15 @@ export const withClaimRewards = async (
     const rewardMintTokenAccountId = params.skipRewardMintTokenAccount
       ? await findAta(
           rewardDistributorData.parsed.rewardMint,
-          wallet.publicKey,
+          params.lastStaker,
           true
         )
       : await withFindOrInitAssociatedTokenAccount(
           transaction,
           connection,
           rewardDistributorData.parsed.rewardMint,
-          wallet.publicKey,
-          wallet.publicKey
+          params.lastStaker,
+          params.payer ?? wallet.publicKey
         );
 
     const remainingAccountsForKind = await withRemainingAccountsForKind(
@@ -150,6 +151,7 @@ export const withClaimRewards = async (
           stakeEntryId: params.stakeEntryId,
           rewardDistributor: rewardDistributorData.pubkey,
           rewardEntryId: rewardEntryId,
+          payer: params.payer,
         })
       );
     }

--- a/src/programs/stakePool/transaction.ts
+++ b/src/programs/stakePool/transaction.ts
@@ -439,6 +439,18 @@ export const withUnstake = async (
     stakeEntryData?.parsed.stakeMint
   );
 
+  // claim any rewards deserved
+  if (rewardDistributorData) {
+    withUpdateTotalStakeSeconds(transaction, connection, wallet, {
+      stakeEntryId: stakeEntryId,
+      lastStaker: wallet.publicKey,
+    });
+    await withClaimRewards(transaction, connection, wallet, {
+      stakePoolId: params.stakePoolId,
+      stakeEntryId: stakeEntryId,
+    });
+  }
+
   transaction.add(
     unstake(connection, wallet, {
       stakePoolId: params.stakePoolId,
@@ -450,14 +462,6 @@ export const withUnstake = async (
       remainingAccounts,
     })
   );
-
-  // claim any rewards deserved
-  if (rewardDistributorData) {
-    await withClaimRewards(transaction, connection, wallet, {
-      stakePoolId: params.stakePoolId,
-      stakeEntryId: stakeEntryId,
-    });
-  }
 
   return transaction;
 };

--- a/src/programs/stakePool/transaction.ts
+++ b/src/programs/stakePool/transaction.ts
@@ -391,6 +391,8 @@ export const withUnstake = async (
     tryGetAccount(() => getRewardDistributor(connection, rewardDistributorId)),
   ]);
 
+  if (!stakeEntryData) throw "Stake entry not found";
+
   const stakePoolData = await getStakePool(connection, params.stakePoolId);
 
   if (
@@ -448,6 +450,7 @@ export const withUnstake = async (
     await withClaimRewards(transaction, connection, wallet, {
       stakePoolId: params.stakePoolId,
       stakeEntryId: stakeEntryId,
+      lastStaker: stakeEntryData?.parsed.lastStaker,
     });
   }
 

--- a/tests/stake-permissionless-claim-rewards.spec.ts
+++ b/tests/stake-permissionless-claim-rewards.spec.ts
@@ -1,0 +1,409 @@
+import { findAta } from "@cardinal/common";
+import { expectTXTable } from "@saberhq/chai-solana";
+import {
+  SignerWallet,
+  SolanaProvider,
+  TransactionEnvelope,
+} from "@saberhq/solana-contrib";
+import type * as splToken from "@solana/spl-token";
+import {
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  Transaction,
+} from "@solana/web3.js";
+import { expect } from "chai";
+
+import {
+  claimRewards,
+  createStakePool,
+  initializeRewardEntry,
+  stake,
+  unstake,
+} from "../src";
+import {
+  getRewardDistributor,
+  getRewardEntry,
+} from "../src/programs/rewardDistributor/accounts";
+import {
+  findRewardDistributorId,
+  findRewardEntryId,
+} from "../src/programs/rewardDistributor/pda";
+import { withInitRewardDistributor } from "../src/programs/rewardDistributor/transaction";
+import { ReceiptType } from "../src/programs/stakePool";
+import { getStakeEntry } from "../src/programs/stakePool/accounts";
+import { findStakeEntryIdFromMint } from "../src/programs/stakePool/utils";
+import { createMasterEditionIxs, createMint, delay } from "./utils";
+import { getProvider } from "./workspace";
+
+describe("Stake and claim permissionless rewards", () => {
+  let originalMintTokenAccountId: PublicKey;
+  let originalMint: splToken.Token;
+  let rewardMint: splToken.Token;
+  let stakePoolId: PublicKey;
+  const originalMintAuthority = Keypair.generate();
+  const rewardClaimer = Keypair.generate();
+
+  before(async () => {
+    const provider = getProvider();
+    // original mint
+    [originalMintTokenAccountId, originalMint] = await createMint(
+      provider.connection,
+      originalMintAuthority,
+      provider.wallet.publicKey,
+      1,
+      originalMintAuthority.publicKey
+    );
+
+    // master edition
+    const ixs = await createMasterEditionIxs(
+      originalMint.publicKey,
+      originalMintAuthority.publicKey
+    );
+    const txEnvelope = new TransactionEnvelope(
+      SolanaProvider.init({
+        connection: provider.connection,
+        wallet: new SignerWallet(originalMintAuthority),
+        opts: provider.opts,
+      }),
+      ixs
+    );
+    await expectTXTable(txEnvelope, "before", {
+      verbosity: "error",
+      formatLogs: true,
+    }).to.be.fulfilled;
+
+    // original mint
+    [, rewardMint] = await createMint(
+      provider.connection,
+      originalMintAuthority,
+      provider.wallet.publicKey,
+      0,
+      provider.wallet.publicKey,
+      provider.wallet.publicKey
+    );
+
+    const fromAirdropSignature = await provider.connection.requestAirdrop(
+      rewardClaimer.publicKey,
+      10 * LAMPORTS_PER_SOL
+    );
+    await provider.connection.confirmTransaction(fromAirdropSignature);
+  });
+
+  it("Create Pool", async () => {
+    const provider = getProvider();
+
+    let transaction: Transaction;
+    [transaction, stakePoolId] = await createStakePool(
+      provider.connection,
+      provider.wallet,
+      {}
+    );
+
+    await expectTXTable(
+      new TransactionEnvelope(SolanaProvider.init(provider), [
+        ...transaction.instructions,
+      ]),
+      "Create pool"
+    ).to.be.fulfilled;
+  });
+
+  it("Create Reward Distributor", async () => {
+    const provider = getProvider();
+    const transaction = new Transaction();
+
+    await withInitRewardDistributor(
+      transaction,
+      provider.connection,
+      provider.wallet,
+      {
+        stakePoolId: stakePoolId,
+        rewardMintId: rewardMint.publicKey,
+      }
+    );
+
+    const txEnvelope = new TransactionEnvelope(SolanaProvider.init(provider), [
+      ...transaction.instructions,
+    ]);
+
+    await expectTXTable(txEnvelope, "Create reward distributor", {
+      verbosity: "error",
+      formatLogs: true,
+    }).to.be.fulfilled;
+
+    const [rewardDistributorId] = await findRewardDistributorId(stakePoolId);
+    const rewardDistributorData = await getRewardDistributor(
+      provider.connection,
+      rewardDistributorId
+    );
+
+    expect(rewardDistributorData.parsed.rewardMint.toString()).to.eq(
+      rewardMint.publicKey.toString()
+    );
+
+    expect(rewardDistributorData.parsed.rewardMint.toString()).to.eq(
+      rewardMint.publicKey.toString()
+    );
+  });
+
+  it("Create Reward Entry", async () => {
+    const provider = getProvider();
+
+    const [rewardDistributorId] = await findRewardDistributorId(stakePoolId);
+    const [stakeEntryId] = await findStakeEntryIdFromMint(
+      provider.connection,
+      provider.wallet.publicKey,
+      stakePoolId,
+      originalMint.publicKey
+    );
+
+    const transaction = await initializeRewardEntry(
+      provider.connection,
+      provider.wallet,
+      {
+        stakePoolId: stakePoolId,
+        originalMintId: originalMint.publicKey,
+      }
+    );
+
+    const txEnvelope = new TransactionEnvelope(SolanaProvider.init(provider), [
+      ...transaction.instructions,
+    ]);
+
+    await expectTXTable(txEnvelope, "Create reward entry", {
+      verbosity: "error",
+      formatLogs: true,
+    }).to.be.fulfilled;
+
+    const [rewardEntryId] = await findRewardEntryId(
+      rewardDistributorId,
+      stakeEntryId
+    );
+
+    const rewardEntryData = await getRewardEntry(
+      provider.connection,
+      rewardEntryId
+    );
+
+    expect(rewardEntryData.parsed.rewardDistributor.toString()).to.eq(
+      rewardDistributorId.toString()
+    );
+
+    expect(rewardEntryData.parsed.stakeEntry.toString()).to.eq(
+      stakeEntryId.toString()
+    );
+  });
+
+  it("Stake", async () => {
+    const provider = getProvider();
+
+    await expectTXTable(
+      new TransactionEnvelope(SolanaProvider.init(provider), [
+        ...(
+          await stake(provider.connection, provider.wallet, {
+            stakePoolId: stakePoolId,
+            originalMintId: originalMint.publicKey,
+            userOriginalMintTokenAccountId: originalMintTokenAccountId,
+            receiptType: ReceiptType.Original,
+          })
+        ).instructions,
+      ]),
+      "Stake"
+    ).to.be.fulfilled;
+
+    const stakeEntryData = await getStakeEntry(
+      provider.connection,
+      (
+        await findStakeEntryIdFromMint(
+          provider.connection,
+          provider.wallet.publicKey,
+          stakePoolId,
+          originalMint.publicKey
+        )
+      )[0]
+    );
+
+    const userOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+
+    expect(stakeEntryData.parsed.lastStakedAt.toNumber()).to.be.greaterThan(0);
+    expect(stakeEntryData.parsed.lastStaker.toString()).to.eq(
+      provider.wallet.publicKey.toString()
+    );
+
+    const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
+      userOriginalMintTokenAccountId
+    );
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(1);
+    expect(checkUserOriginalTokenAccount.isFrozen).to.eq(true);
+  });
+
+  it("Claim Rewards fail", async () => {
+    await delay(2000);
+    const provider = getProvider();
+    const [stakeEntryId] = await findStakeEntryIdFromMint(
+      provider.connection,
+      provider.wallet.publicKey,
+      stakePoolId,
+      originalMint.publicKey
+    );
+    expect(async () => {
+      await expectTXTable(
+        new TransactionEnvelope(SolanaProvider.init(provider), [
+          ...(
+            await claimRewards(
+              provider.connection,
+              new SignerWallet(rewardClaimer),
+              {
+                stakePoolId: stakePoolId,
+                stakeEntryId: stakeEntryId,
+              }
+            )
+          ).instructions,
+        ]),
+        "Claim Rewards fail"
+      ).to.be.rejectedWith(Error);
+    });
+  });
+
+  it("Claim Rewards", async () => {
+    await delay(2000);
+    const provider = getProvider();
+    const [stakeEntryId] = await findStakeEntryIdFromMint(
+      provider.connection,
+      provider.wallet.publicKey,
+      stakePoolId,
+      originalMint.publicKey
+    );
+    const oldStakeEntryData = await getStakeEntry(
+      provider.connection,
+      stakeEntryId
+    );
+
+    await expectTXTable(
+      new TransactionEnvelope(
+        SolanaProvider.init({
+          connection: provider.connection,
+          wallet: new SignerWallet(rewardClaimer),
+          opts: provider.opts,
+        }),
+        [
+          ...(
+            await claimRewards(
+              provider.connection,
+              new SignerWallet(rewardClaimer),
+              {
+                stakePoolId: stakePoolId,
+                stakeEntryId: stakeEntryId,
+                lastStaker: oldStakeEntryData.parsed.lastStaker,
+              }
+            )
+          ).instructions,
+        ]
+      ),
+      "Claim Rewards"
+    ).to.be.fulfilled;
+
+    const newStakeEntryData = await getStakeEntry(
+      provider.connection,
+      stakeEntryId
+    );
+    expect(newStakeEntryData.parsed.lastStaker.toString()).to.eq(
+      provider.wallet.publicKey.toString()
+    );
+    expect(newStakeEntryData.parsed.lastStakedAt.toNumber()).to.gt(
+      oldStakeEntryData.parsed.lastStakedAt.toNumber()
+    );
+    expect(newStakeEntryData.parsed.totalStakeSeconds.toNumber()).to.gt(
+      oldStakeEntryData.parsed.totalStakeSeconds.toNumber()
+    );
+
+    const userRewardMintTokenAccountId = await findAta(
+      rewardMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+
+    const checkUserRewardTokenAccount = await rewardMint.getAccountInfo(
+      userRewardMintTokenAccountId
+    );
+    expect(checkUserRewardTokenAccount.amount.toNumber()).greaterThan(1);
+
+    const userOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+    const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
+      userOriginalMintTokenAccountId
+    );
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(1);
+    expect(checkUserOriginalTokenAccount.isFrozen).to.eq(true);
+  });
+
+  it("Unstake", async () => {
+    const provider = getProvider();
+    await expectTXTable(
+      new TransactionEnvelope(SolanaProvider.init(provider), [
+        ...(
+          await unstake(provider.connection, provider.wallet, {
+            stakePoolId: stakePoolId,
+            originalMintId: originalMint.publicKey,
+          })
+        ).instructions,
+      ]),
+      "Unstake"
+    ).to.be.fulfilled;
+
+    const stakeEntryData = await getStakeEntry(
+      provider.connection,
+      (
+        await findStakeEntryIdFromMint(
+          provider.connection,
+          provider.wallet.publicKey,
+          stakePoolId,
+          originalMint.publicKey
+        )
+      )[0]
+    );
+    expect(stakeEntryData.parsed.lastStaker.toString()).to.eq(
+      PublicKey.default.toString()
+    );
+    expect(stakeEntryData.parsed.lastStakedAt.toNumber()).to.gt(0);
+
+    const userOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+    const checkUserOriginalTokenAccount = await originalMint.getAccountInfo(
+      userOriginalMintTokenAccountId
+    );
+    expect(checkUserOriginalTokenAccount.amount.toNumber()).to.eq(1);
+    expect(checkUserOriginalTokenAccount.isFrozen).to.eq(false);
+
+    const stakeEntryOriginalMintTokenAccountId = await findAta(
+      originalMint.publicKey,
+      stakeEntryData.pubkey,
+      true
+    );
+
+    const userRewardMintTokenAccountId = await findAta(
+      rewardMint.publicKey,
+      provider.wallet.publicKey,
+      true
+    );
+
+    const checkStakeEntryOriginalMintTokenAccount =
+      await originalMint.getAccountInfo(stakeEntryOriginalMintTokenAccountId);
+    expect(checkStakeEntryOriginalMintTokenAccount.amount.toNumber()).to.eq(0);
+
+    const checkUserRewardTokenAccount = await rewardMint.getAccountInfo(
+      userRewardMintTokenAccountId
+    );
+    expect(checkUserRewardTokenAccount.amount.toNumber()).greaterThan(1);
+  });
+});


### PR DESCRIPTION
1. Allowing ability to update someone elses total_stake_seconds
- this will set a kind called Permissionless indicating that claim_rewards must check last_staker

2. Changing the order of withUnstake -> withClaimRewards to do udpate, claim, unstake so that it can still check last_staker